### PR TITLE
Support for unicode filenames

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -6,6 +6,7 @@ Parameter, allowing users to view and and manipulate Parameter values
 from within a Jupyter/IPython notebook.
 """
 
+import sys
 import time
 import glob
 
@@ -20,6 +21,10 @@ import ipywidgets
 
 import param
 from param.parameterized import classlist
+
+if sys.version_info.major == 3:
+    unicode = str
+    basestring = str
 
 
 def abbreviate_paths(pathspec,named_paths):
@@ -165,8 +170,16 @@ def named_objs(objlist):
     Given a list of objects, returns a dictionary mapping from
     string name for the object to the object itself.
     """
-    return {k.__name__ if hasattr(k, '__name__') else str(k) : obj
-            for k,obj in objlist}
+    objs = {}
+    for k, obj in objlist:
+        if hasattr(k, '__name__'):
+            k = k.__name__
+        elif isinstance(k, basestring):
+            k = unicode(k.decode('utf-8'))
+        else:
+            k = unicode(k)
+        objs[k] = obj
+    return objs
 
 
 class Widgets(param.ParameterizedFunction):


### PR DESCRIPTION
As the title says, ipywidgets was throwing errors when the filenames contained unicode characters.
