### PR TITLE
Defined initializer system including JSON initializer

### DIFF
--- a/Using_EnvironmentInit.ipynb
+++ b/Using_EnvironmentInit.ipynb
@@ -314,6 +314,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that you can use ``EnvironmentInit`` without setting any environment variables by specifying the JSON file directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit.instance(json_file='param_init.json'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },

--- a/Using_EnvironmentInit.ipynb
+++ b/Using_EnvironmentInit.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setting parameters via environment variables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "For all the examples in this notebook to work, launch the notebook server using:\n",
+    "\n",
+    "```\n",
+    "PARAMNB_INIT='{\"p1\":5}' \\\n",
+    " TARGETED='{\"Target1\":{\"p1\":3}, \"Target2\":{\"s\":\"test\"}}' \\\n",
+    " CUSTOM='{\"custom\":{\"val\":99}}' jupyter notebook\n",
+    "```\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import param\n",
+    "import paramnb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first minimal example will work if the notebook server is launched as follows:\n",
+    "\n",
+    "```\n",
+    "PARAMNB_INIT='{\"p1\":5}' jupyter notebook\n",
+    "```\n",
+    "\n",
+    "First let's show that the ``'PARAMNB_INIT'`` environment is defined:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "os.environ['PARAMNB_INIT']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This string is JSON and the 'PARAMNB_INIT' is the default environment variable name to set parameters via the commandline. Lets make a simple parameterized class with a ``p1`` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Test(param.Parameterized):\n",
+    "    \n",
+    "    p1 = param.Number(default=1, bounds=(0,10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now if we supply ``paramnb.EnvironmentInit`` as an initializer, the ``p1`` parameter is set from the default of 1 to the value of 5 specified by the environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The second example will work if the notebook server is launched as follows:\n",
+    "\n",
+    "```\n",
+    "TARGETED='{\"Target1\":{\"p1\":3}, \"Target2\":{\"s\":\"test\"}}' jupyter notebook\n",
+    "```\n",
+    "\n",
+    "In this example, we show how you can target parameters to different classes using a different environment variable called ``TARGETED``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "os.environ['TARGETED']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the keys are class names and the corresponding dictionary values are the parameter values to override. Let's defined classes ``Target1`` and ``Target2`` with parameters ``p1`` and ``s`` respectively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Target1(param.Parameterized):\n",
+    "    \n",
+    "    p1 = param.Number(default=1, bounds=(0,10))\n",
+    "\n",
+    "class Target2(param.Parameterized):\n",
+    "    \n",
+    "    s = param.String(default=\"default\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now lets use ``paramnb.Widgets`` on ``Target1``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "paramnb.Widgets(Target1, initializer=paramnb.EnvironmentInit.instance(varname='TARGETED'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The value of ``p1`` is now ``3`` as requested.\n",
+    "\n",
+    "Now lets use ``paramnb.Widgets`` on ``Target2``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "paramnb.Widgets(Target2, initializer=paramnb.EnvironmentInit.instance(varname='TARGETED'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Example 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The third example will work if the notebook server is launched as follows:\n",
+    "\n",
+    "```\n",
+    "CUSTOM='{\"custom\":{\"val\":99}}' jupyter notebook\n",
+    "```\n",
+    "\n",
+    "In this example, we show how you can target a specific instance using an environment variable called ``CUSTOM``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "os.environ['CUSTOM']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Example(param.Parameterized):\n",
+    "    \n",
+    "    val = param.Number(default=1, bounds=(0,100))\n",
+    "    \n",
+    "instance = Example()\n",
+    "paramnb.Widgets(instance, initializer=paramnb.EnvironmentInit.instance(varname='CUSTOM', target='custom'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Tips"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "* It is recommended that you target at the class or instance level if you ever intend to use ``EnvironmentInit`` to customize different sets of parameters.\n",
+    "\n",
+    "* It is recommended that you validate (and pretty print) the JSON at the commandline using ``json.tool``. For instance, you can validate the JSON for the first example before launching the server as follows:\n",
+    "\n",
+    "```\n",
+    "PARAMNB_INIT=`echo '{\"p1\":5}' | python -mjson.tool` jupyter notebook\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/Using_EnvironmentInit.ipynb
+++ b/Using_EnvironmentInit.ipynb
@@ -250,6 +250,70 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use a JSON file ending with the '.json' extension. For instance, if you execute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "json.dump({\"p1\":5}, open('param_init.json', 'w'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You cam specify the full path or relative path to the JSON file with:\n",
+    "\n",
+    "\n",
+    "```\n",
+    "PARAMNB_INIT=param_init.json jupyter notebook\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "os.environ['PARAMNB_INIT']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Test(param.Parameterized):\n",
+    "    \n",
+    "    p1 = param.Number(default=1, bounds=(0,10))\n",
+    "    \n",
+    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },

--- a/Using_JSONInit.ipynb
+++ b/Using_JSONInit.ipynb
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now if we supply ``paramnb.EnvironmentInit`` as an initializer, the ``p1`` parameter is set from the default of 1 to the value of 5 specified by the environment variable:"
+    "Now if we supply ``paramnb.JSONInit`` as an initializer, the ``p1`` parameter is set from the default of 1 to the value of 5 specified by the environment variable:"
    ]
   },
   {
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit)"
+    "paramnb.Widgets(Test, initializer=paramnb.JSONInit)"
    ]
   },
   {
@@ -175,7 +175,7 @@
    },
    "outputs": [],
    "source": [
-    "paramnb.Widgets(Target1, initializer=paramnb.EnvironmentInit.instance(varname='TARGETED'))"
+    "paramnb.Widgets(Target1, initializer=paramnb.JSONInit.instance(varname='TARGETED'))"
    ]
   },
   {
@@ -195,7 +195,7 @@
    },
    "outputs": [],
    "source": [
-    "paramnb.Widgets(Target2, initializer=paramnb.EnvironmentInit.instance(varname='TARGETED'))"
+    "paramnb.Widgets(Target2, initializer=paramnb.JSONInit.instance(varname='TARGETED'))"
    ]
   },
   {
@@ -245,7 +245,7 @@
     "    val = param.Number(default=1, bounds=(0,100))\n",
     "    \n",
     "instance = Example()\n",
-    "paramnb.Widgets(instance, initializer=paramnb.EnvironmentInit.instance(varname='CUSTOM', target='custom'))"
+    "paramnb.Widgets(instance, initializer=paramnb.JSONInit.instance(varname='CUSTOM', target='custom'))"
    ]
   },
   {
@@ -309,14 +309,14 @@
     "    \n",
     "    p1 = param.Number(default=1, bounds=(0,10))\n",
     "    \n",
-    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit)"
+    "paramnb.Widgets(Test, initializer=paramnb.JSONInit)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that you can use ``EnvironmentInit`` without setting any environment variables by specifying the JSON file directly:"
+    "Note that you can use ``JSONInit`` without setting any environment variables by specifying the JSON file directly:"
    ]
   },
   {
@@ -327,7 +327,7 @@
    },
    "outputs": [],
    "source": [
-    "paramnb.Widgets(Test, initializer=paramnb.EnvironmentInit.instance(json_file='param_init.json'))"
+    "paramnb.Widgets(Test, initializer=paramnb.JSONInit.instance(json_file='param_init.json'))"
    ]
   },
   {
@@ -344,7 +344,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "* It is recommended that you target at the class or instance level if you ever intend to use ``EnvironmentInit`` to customize different sets of parameters.\n",
+    "* It is recommended that you target at the class or instance level if you ever intend to use ``JSONInit`` to customize different sets of parameters.\n",
     "\n",
     "* It is recommended that you validate (and pretty print) the JSON at the commandline using ``json.tool``. For instance, you can validate the JSON for the first example before launching the server as follows:\n",
     "\n",

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -327,7 +327,11 @@ class Widgets(param.ParameterizedFunction):
 class JSONInit(param.ParameterizedFunction):
     """
     Callable that can be passed to Widgets.initializer to set Parameter
-    values based on environment variables encoding JSON.
+    values using JSON. There are three approaches that may be used:
+
+    1. If the json_file argument is specified, this takes precedence.
+    2. The JSON file path can be specified via an environment variable.
+    3. The JSON can be read directly from an environment variable.
 
     Here is an easy example of setting such an environment variable on
     the commandline:

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -325,6 +325,21 @@ class Widgets(param.ParameterizedFunction):
 
 
 class EnvironmentInit(param.Parameterized):
+    """
+    Callable that can be passed to Widgets.initializer to set Parameter
+    values based on environment variables encoding JSON.
+
+    Here is an easy example of setting such an environment variable on
+    the commandline with validation:
+
+
+    PARAMNB_INIT=`echo '{"example":{"p1":3}}' | python -mjson.tool` jupyter notebook
+
+    This addresses any EnvironmentInit instances inspecting an
+    environment variable with varname PARAMNB_INIT and target
+    'example'. The result is to set any parameter named 'p1' to the
+    value 3.
+    """
 
     varname = param.String(default='PARAMNB_INIT', doc="""
         The name of the environment variable containing the JSON

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -359,7 +359,14 @@ class EnvironmentInit(param.ParameterizedFunction):
         env_var = os.environ.get(p.varname, None)
         if env_var is None: return
 
-        spec = json.loads(env_var)
+        if env_var.endswith('.json'):
+            try:
+                spec = json.load(open(os.path.abspath(env_var), 'r'))
+            except:
+                warnobj.warning('Could not load JSON file %r' % spec)
+        else:
+            spec = json.loads(env_var)
+
         if not isinstance(spec, dict):
             warnobj.warning('JSON parameter specification must be a dictionary.')
             return

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -334,9 +334,9 @@ class EnvironmentInit(param.ParameterizedFunction):
 
     PARAMNB_INIT='{"p1":5}' jupyter notebook
 
-    This addresses any EnvironmentInit instances that is inspecting the
-    default environment variable called PARAMNB_INIT in order to set the
-    'p1' parameter to 5.
+    This addresses any EnvironmentInit instances that are inspecting the
+    default environment variable called PARAMNB_INIT, instructing it to set
+    the 'p1' parameter to 5.
     """
 
     varname = param.String(default='PARAMNB_INIT', doc="""

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -167,8 +167,18 @@ class Widgets(param.ParameterizedFunction):
         to the top of the list, and other values above the default_precedence
         values can be used to sort or group parameters arbitrarily.""")
 
+    initializer = param.Callable(default=None, doc="""
+        User-supplied function that will be called on initialization,
+        usually to update the default Parameter values of the
+        underlying parameterized object.""")
+
     def __call__(self, parameterized, **params):
+
+
         self.p = param.ParamOverrides(self, params)
+        if self.p.initializer:
+            self.p.initializer(parameterized)
+
         self._widgets = {}
         self.parameterized = parameterized
 

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -347,6 +347,9 @@ class EnvironmentInit(param.ParameterizedFunction):
         Optional key in the JSON specification dictionary containing the
         desired parameter values.""")
 
+    json_file = param.String(default=None, doc="""
+        Optional path to a JSON file containing the parameter settings.""")
+
     def __call__(self, parameterized):
 
         warnobj = param.main if isinstance(parameterized, type) else parameterized
@@ -357,11 +360,12 @@ class EnvironmentInit(param.ParameterizedFunction):
         target = p.target if p.target is not None else param_class.__name__
 
         env_var = os.environ.get(p.varname, None)
-        if env_var is None: return
+        if env_var is None and p.json_file is None: return
 
-        if env_var.endswith('.json'):
+        if p.json_file or env_var.endswith('.json'):
             try:
-                spec = json.load(open(os.path.abspath(env_var), 'r'))
+                fname = p.json_file if p.json_file else env_var
+                spec = json.load(open(os.path.abspath(fname), 'r'))
             except:
                 warnobj.warning('Could not load JSON file %r' % spec)
         else:

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -330,15 +330,13 @@ class EnvironmentInit(param.ParameterizedFunction):
     values based on environment variables encoding JSON.
 
     Here is an easy example of setting such an environment variable on
-    the commandline with validation:
+    the commandline:
 
+    PARAMNB_INIT='{"p1":5}' jupyter notebook
 
-    PARAMNB_INIT=`echo '{"example":{"p1":3}}' | python -mjson.tool` jupyter notebook
-
-    This addresses any EnvironmentInit instances inspecting an
-    environment variable with varname PARAMNB_INIT and target
-    'example'. The result is to set any parameter named 'p1' to the
-    value 3.
+    This addresses any EnvironmentInit instances that is inspecting the
+    default environment variable called PARAMNB_INIT in order to set the
+    'p1' parameter to 5.
     """
 
     varname = param.String(default='PARAMNB_INIT', doc="""

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -324,7 +324,7 @@ class Widgets(param.ParameterizedFunction):
         return widgets
 
 
-class EnvironmentInit(param.ParameterizedFunction):
+class JSONInit(param.ParameterizedFunction):
     """
     Callable that can be passed to Widgets.initializer to set Parameter
     values based on environment variables encoding JSON.
@@ -334,7 +334,7 @@ class EnvironmentInit(param.ParameterizedFunction):
 
     PARAMNB_INIT='{"p1":5}' jupyter notebook
 
-    This addresses any EnvironmentInit instances that are inspecting the
+    This addresses any JSONInit instances that are inspecting the
     default environment variable called PARAMNB_INIT, instructing it to set
     the 'p1' parameter to 5.
     """

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -384,7 +384,4 @@ class EnvironmentInit(param.ParameterizedFunction):
            try:
                parameterized.set_param(**{name:value})
            except ValueError as e:
-               if isinstance(parameterized, type):
-                   warnobj.warning(str(e))
-               else:
-                   warnobj.warning(str(e))
+               warnobj.warning(str(e))


### PR DESCRIPTION
This PR makes it possible to set Widget parameters by setting parameters via the commandline.

For instance, using:

```
PARAMNB_INIT=`echo '{"example":{"p1":3}}' | python -mjson.tool` jupyter notebook
```

Allows you to change a parameter value from its default of 1 to 3:

![image](https://cloud.githubusercontent.com/assets/890576/18551812/fab40c62-7b51-11e6-8998-0effca187cea.png)

This design should make it easy to specify multiple sets of parameters for multiple different notebooks using a single environment variable (called `PARAMNB_INIT` by default) as long as unique targets are specified ('example' in the above screenshot).
