### PR TITLE
Added display option to Widgets

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -177,8 +177,12 @@ class Widgets(param.ParameterizedFunction):
     layout = param.ObjectSelector(default='column',
                                   objects=['row','column'],doc="""
         Whether to lay out the buttons as a row or a column.""")
-                                       
-    
+
+    display = param.Boolean(default=True, doc="""
+        Whether or not to display the widgets. Useful for batch running
+        notebooks.""")
+
+
     def __call__(self, parameterized, **params):
 
 
@@ -193,7 +197,8 @@ class Widgets(param.ParameterizedFunction):
         layout = ipywidgets.Layout(display='flex', flex_flow=self.p.layout)
         vbox = ipywidgets.VBox(children=widgets, layout=layout)
 
-        display(vbox)
+        if self.p.display:
+            display(vbox)
 
         if self.p.on_init:
             self.execute(None)


### PR DESCRIPTION
When trying to batch generate notebooks with nbconvert using the execute preprocessor, widgets don't display in the HTML export and show this ugly message:

![image](https://cloud.githubusercontent.com/assets/890576/19479502/f50280a8-953e-11e6-8e16-a133368f6ab1.png)

For this reason, it seems useful to have an option to disable display for notebooks that are to be batch run by setting `paramnb.Widgets.display=False`. This makes sense to me as widgets don't export to HTML anyway so suppressing those ugly (and irrelevant) warnings seems like a reasonable thing to do.

One other possibility would be to offer a display type. Perhaps a textual display of the current parameter values would be even more useful?
