### PR TITLE
Multi select

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -5,14 +5,13 @@ Given a Parameterized object, displays a box with an ipywidget for each
 Parameter, allowing users to view and and manipulate Parameter values
 from within a Jupyter/IPython notebook.
 """
+from __future__ import absolute_import
 
 import sys
 import os
 import types
 import itertools
 import json
-
-from collections import OrderedDict
 
 from IPython import get_ipython
 from IPython.display import display, Javascript
@@ -22,12 +21,10 @@ import ipywidgets
 import param
 from param.parameterized import classlist
 
+from .util import named_objs
+
 __version__ = param.Version(release=(1,0,2), fpath=__file__,
                              commit="$Format:%h$", reponame='paramnb')
-
-if sys.version_info.major == 3:
-    unicode = str
-    basestring = str
 
 
 def FloatWidget(*args, **kw):
@@ -114,23 +111,6 @@ def estimate_label_width(labels):
     """
     max_length = max([len(l) for l in labels])
     return "{0}px".format(max(60,int(max_length*7.5)))
-
-
-def named_objs(objlist):
-    """
-    Given a list of objects, returns a dictionary mapping from
-    string name for the object to the object itself.
-    """
-    objs = OrderedDict()
-    for k, obj in objlist:
-        if hasattr(k, '__name__'):
-            k = k.__name__
-        elif sys.version_info < (3,0) and isinstance(k, basestring):
-            k = unicode(k.decode('utf-8'))
-        else:
-            k = unicode(k)
-        objs[k] = obj
-    return objs
 
 
 class Widgets(param.ParameterizedFunction):

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -21,6 +21,7 @@ import ipywidgets
 import param
 from param.parameterized import classlist
 
+from .widgets import CrossSelect
 from .util import named_objs
 
 __version__ = param.Version(release=(1,0,2), fpath=__file__,
@@ -51,6 +52,14 @@ def HTMLWidget(*args, **kw):
     return ipywidgets.HTML(*args,**kw)
 
 
+def ListSelectorWidget(*args, **kw):
+    """Forces a parameter value to be text, displayed as HTML"""
+    if len(kw['options']) > 20:
+        return CrossSelect(*args, **kw)
+    else:
+        return ipywidgets.SelectMultiple(*args, **kw)
+
+
 def ActionButton(*args, **kw):
     """Returns a ipywidgets.Button executing a paramnb.Action."""
     kw['description'] = str(kw['name'])
@@ -66,7 +75,7 @@ ptype2wtype = {
     param.Boolean:       ipywidgets.Checkbox,
     param.Number:        FloatWidget,
     param.Integer:       IntegerWidget,
-    param.ListSelector:  ipywidgets.SelectMultiple,
+    param.ListSelector:  ListSelectorWidget,
     param.Action:        ActionButton,
 }
 

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -250,7 +250,8 @@ class Widgets(param.ParameterizedFunction):
 
             path_w = ipywidgets.Text(value=p_obj.path)
             path_w.observe(path_change_event, 'value')
-            w = ipywidgets.VBox(children=[path_w,w])
+            w = ipywidgets.VBox(children=[path_w,w],
+                                layout=ipywidgets.Layout(margin='0'))
 
         return w
 

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -52,12 +52,25 @@ def HTMLWidget(*args, **kw):
     return ipywidgets.HTML(*args,**kw)
 
 
-def ListSelectorWidget(*args, **kw):
-    """Forces a parameter value to be text, displayed as HTML"""
-    if len(kw['options']) > 20:
-        return CrossSelect(*args, **kw)
-    else:
-        return ipywidgets.SelectMultiple(*args, **kw)
+class ListSelectorWidget(param.ParameterizedFunction):
+    """
+    Selects the appropriate ListSelector widget depending on the number
+    of items.
+    """
+
+    item_limit = param.Integer(default=20, allow_None=True, doc="""
+        The number of items in the ListSelector before it switches from
+        a regular SelectMultiple widget to a two-pane CrossSelect widget.
+        Setting the limit to None will disable the CrossSelect widget
+        completely while a negative value will force it to be enabled.
+    """)
+
+    def __call__(self, *args, **kw):
+        item_limit = kw.pop('item_limit', self.item_limit)
+        if item_limit is not None and len(kw['options']) > item_limit:
+            return CrossSelect(*args, **kw)
+        else:
+            return ipywidgets.SelectMultiple(*args, **kw)
 
 
 def ActionButton(*args, **kw):

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -269,6 +269,7 @@ class Widgets(param.ParameterizedFunction):
              z-index: 100; min-width: 100px; font-size: 80%}
           .ttip:hover .ttiptext { visibility: visible; }
           .widget-dropdown .dropdown-menu { width: 100% }
+          .widget-select-multiple select { min-height: 140px; min-width: 300px;}
         </style>
         """
 

--- a/paramnb/util.py
+++ b/paramnb/util.py
@@ -12,10 +12,8 @@ def as_unicode(obj):
     (i.e. bytes) types in python 2.
     """
     if sys.version_info.major < 3 and isinstance(obj, str):
-        obj = unicode(obj.decode('utf-8'))
-    else:
-        obj = unicode(obj)
-    return obj
+        obj = obj.decode('utf-8')
+    return unicode(obj)
 
 
 def named_objs(objlist):

--- a/paramnb/util.py
+++ b/paramnb/util.py
@@ -1,0 +1,23 @@
+import sys
+from collections import OrderedDict
+
+if sys.version_info.major == 3:
+    unicode = str
+    basestring = str
+
+def named_objs(objlist):
+    """
+    Given a list of objects, returns a dictionary mapping from
+    string name for the object to the object itself.
+    """
+    objs = OrderedDict()
+    for k, obj in objlist:
+        if hasattr(k, '__name__'):
+            k = k.__name__
+        elif sys.version_info < (3,0) and isinstance(k, basestring) and not isinstance(k, unicode):
+            k = unicode(k.decode('utf-8'))
+        else:
+            k = unicode(k)
+        objs[k] = obj
+    return objs
+

--- a/paramnb/util.py
+++ b/paramnb/util.py
@@ -5,6 +5,19 @@ if sys.version_info.major == 3:
     unicode = str
     basestring = str
 
+
+def as_unicode(obj):
+    """
+    Safely casts any object to unicode including regular string
+    (i.e. bytes) types in python 2.
+    """
+    if sys.version_info.major < 3 and isinstance(obj, str):
+        obj = unicode(obj.decode('utf-8'))
+    else:
+        obj = unicode(obj)
+    return obj
+
+
 def named_objs(objlist):
     """
     Given a list of objects, returns a dictionary mapping from
@@ -14,10 +27,7 @@ def named_objs(objlist):
     for k, obj in objlist:
         if hasattr(k, '__name__'):
             k = k.__name__
-        elif sys.version_info < (3,0) and isinstance(k, basestring) and not isinstance(k, unicode):
-            k = unicode(k.decode('utf-8'))
         else:
-            k = unicode(k)
+            k = as_unicode(k)
         objs[k] = obj
     return objs
-

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -8,7 +8,7 @@ from .util import named_objs
 
 class CrossSelect(SelectMultiple):
     """
-    CrossSelect provides a two-tab multi-selection widgets with fnmatch
+    CrossSelect provides a two-tab multi-selection widget with regex
     text filtering. Items can be transferred with buttons between the
     selected and unselected options.
     """

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -69,7 +69,7 @@ class CrossSelect(SelectMultiple):
         for the whole widget are updated.
         """
         self._reverse_lookup = {v: k for k, v in event['new'].items()}
-        options = event['new'].keys() if isinstance(event, dict) else event['new']
+        options = list(event['new'].keys()) if isinstance(event, dict) else event['new']
         self._selected[False] = []
         self._selected[True] = []
         self._lists[True].options = ['']

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -23,10 +23,8 @@ class CrossSelect(SelectMultiple):
         unselected = [k for k in options if k not in selected]
 
         # Define whitelist and blacklist
-        left_layout = Layout(min_width='0px')
-        right_layout = Layout(min_width='0px', margin='38px 0 0 10px')
-        self._lists = {False: SelectMultiple(options=unselected, layout=left_layout),
-                       True: SelectMultiple(options=selected, layout=right_layout)}
+        self._lists = {False: SelectMultiple(options=unselected),
+                       True: SelectMultiple(options=selected)}
 
         self._lists[False].observe(self._update_selection, 'value')
         self._lists[True].observe(self._update_selection, 'value')
@@ -43,11 +41,12 @@ class CrossSelect(SelectMultiple):
         self._search.observe(self._filter_options, 'value')
 
         # Define Layout
+        search_row = HBox([self._search])
         button_box = VBox([self._buttons[True], self._buttons[False]],
                           layout=Layout(margin='auto 0'))
-        self._composite = HBox([VBox([self._search, self._lists[False]]),
-                                button_box, self._lists[True]],
-                               layout=Layout(margin='0'))
+        tab_row = HBox([self._lists[False], button_box, self._lists[True]],
+                       layout=Layout(margin='0'))
+        self._composite = VBox([search_row, tab_row])
 
         self.observe(self._update_options, 'options')
         self.observe(self._update_value, 'value')

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -39,7 +39,7 @@ class CrossSelect(SelectMultiple):
         self._buttons[True].on_click(self._apply_selection)
 
         # Define search
-        self._search = Text()
+        self._search = Text(placeholder='Filter options')
         self._search.observe(self._filter_options, 'value')
 
         # Define Layout

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -41,12 +41,13 @@ class CrossSelect(SelectMultiple):
         self._search.observe(self._filter_options, 'value')
 
         # Define Layout
-        search_row = HBox([self._search])
+        no_margin = Layout(margin='0')
+        search_row = HBox([self._search], layout=no_margin)
         button_box = VBox([self._buttons[True], self._buttons[False]],
                           layout=Layout(margin='auto 0'))
         tab_row = HBox([self._lists[False], button_box, self._lists[True]],
-                       layout=Layout(margin='0'))
-        self._composite = VBox([search_row, tab_row])
+                       layout=no_margin)
+        self._composite = VBox([search_row, tab_row], layout=no_margin)
 
         self.observe(self._update_options, 'options')
         self.observe(self._update_value, 'value')

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -129,13 +129,9 @@ class CrossSelect(SelectMultiple):
         self._composite._ipython_display_(**kwargs)
     
     def get_state(self, key=None, drop_defaults=False):
-        """
-        HACK: Let's this composite widget pretend to be a regular widget
-        when included into a layout.
-        """
-        if key == 'value':
-            return {'value': self._lists[True].options}
-        elif key == '_options_labels':
+        # HACK: Let's this composite widget pretend to be a regular widget
+        # when included into a layout.
+        if key in ['value', '_options_labels']:
             return super(CrossSelect, self).get_state(key, drop_defaults)
         return self._composite.get_state(key, drop_defaults)
 

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -37,12 +37,15 @@ class CrossSelect(SelectMultiple):
         self._buttons[True].on_click(self._apply_selection)
 
         # Define search
-        self._search = Text(placeholder='Filter options')
-        self._search.observe(self._filter_options, 'value')
+        self._search = {False: Text(placeholder='Filter available options'),
+                        True: Text(placeholder='Filter selected options')}
+        self._search[False].observe(self._filter_options, 'value')
+        self._search[True].observe(self._filter_options, 'value')
 
         # Define Layout
         no_margin = Layout(margin='0')
-        search_row = HBox([self._search], layout=no_margin)
+        search_layout = Layout(margin='0', display='flex', justify_content='space-between')
+        search_row = HBox([self._search[False], self._search[True]], layout=search_layout)
         button_box = VBox([self._buttons[True], self._buttons[False]],
                           layout=Layout(margin='auto 0'))
         tab_row = HBox([self._lists[False], button_box, self._lists[True]],
@@ -53,7 +56,7 @@ class CrossSelect(SelectMultiple):
         self.observe(self._update_value, 'value')
 
         self._selected = {False: [], True: []}
-        self._query = ''
+        self._query = {False: '', True: ''}
         super(CrossSelect, self).__init__(*args, **dict(kwargs, options=options))
 
 
@@ -77,25 +80,33 @@ class CrossSelect(SelectMultiple):
         self._lists[True].value = []
         self._lists[False].options = options
         self._lists[False].value = []
-        self._filter_options()
+        self._apply_filters()
 
-    def _filter_options(self, event=None):
+    def _apply_filters(self):
+        self._filter_options({'owner': self._search[False]})
+        self._filter_options({'owner': self._search[True]})
+
+    def _filter_options(self, event):
         """
         Filters unselected options based on a text query event.
         """
-        query = self._query if event is None else event['new'] 
-        self._query = query
-        whitelist = self._lists[True].options
-        options = [o for o in self.options
-                   if o not in whitelist]
+        selected = event['owner'] is self._search[True]
+        query = self._query[selected] if 'new' not in event else event['new']
+        self._query[selected] = query
+        other = self._lists[not selected].options
+        options = [o for o in self.options if o not in other]
         if not query:
-            self._lists[False].options = options
-            self._lists[False].value = []
+            self._lists[selected].options = options
+            self._lists[selected].value = []
         else:
-            match = re.compile(query)
-            matches = filter(match.search, options)
-            self._lists[False].options = matches if matches else ['']
-            self._lists[False].value = matches
+            try:
+                match = re.compile(query)
+                matches = filter(match.search, options)
+                options = matches + [opt for opt in options if opt not in matches]
+            except:
+                matches = options
+            self._lists[selected].options = options if options else ['']
+            self._lists[selected].value = matches
 
     def _update_selection(self, event):
         """
@@ -113,14 +124,14 @@ class CrossSelect(SelectMultiple):
         new = self._selected[not selected]
         old = self._lists[selected].options
         other = self._lists[not selected].options
-        
+
         merged = sorted([v for v in list(old) + list(new) if v != ''])
         leftovers = sorted([o for o in other if o not in new and o != ''])
         new_values = merged if selected else leftovers
         self._lists[selected].options = merged if merged else ['']
         self._lists[not selected].options = leftovers if leftovers else ['']
         self.value = [self._options_dict[o] for o in self._lists[True].options if o != '']
-        self._filter_options()
+        self._apply_filters()
 
     def _ipython_display_(self, **kwargs):
         """

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -1,4 +1,4 @@
-import fnmatch
+import re
 
 import param
 from ipywidgets import SelectMultiple, Button, HBox, VBox, Layout, Text
@@ -92,7 +92,8 @@ class CrossSelect(SelectMultiple):
             self._lists[False].options = options
             self._lists[False].value = []
         else:
-            matches = fnmatch.filter(options, query+'*')
+            match = re.compile(query)
+            matches = filter(match.search, options)
             self._lists[False].options = matches if matches else ['']
             self._lists[False].value = matches
 

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -1,0 +1,140 @@
+import fnmatch
+
+import param
+from ipywidgets import SelectMultiple, Button, HBox, VBox, Layout, Text
+
+from .util import named_objs
+
+
+class CrossSelect(SelectMultiple):
+    """
+    CrossSelect provides a two-tab multi-selection widgets with fnmatch
+    text filtering. Items can be transferred with buttons between the
+    selected and unselected options.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Compute selected and unselected values
+        options = kwargs.get('options', {})
+        if isinstance(options, list):
+            options = named_objs([(opt, opt) for opt in options])
+        self._reverse_lookup = {v: k for k, v in options.items()}
+        selected = [self._reverse_lookup[v] for v in kwargs.get('value', [])]
+        unselected = [k for k in options if k not in selected]
+
+        # Define whitelist and blacklist
+        left_layout = Layout(min_width='0px')
+        right_layout = Layout(min_width='0px', margin='38px 0 0 10px')
+        self._lists = {False: SelectMultiple(options=unselected, layout=left_layout),
+                       True: SelectMultiple(options=selected, layout=right_layout)}
+
+        self._lists[False].observe(self._update_selection, 'value')
+        self._lists[True].observe(self._update_selection, 'value')
+
+        # Define buttons
+        button_layout = Layout(width='50px')
+        self._buttons = {False: Button(description='<<', layout=button_layout),
+                         True: Button(description='>>', layout=button_layout)}
+        self._buttons[False].on_click(self._apply_selection)
+        self._buttons[True].on_click(self._apply_selection)
+
+        # Define search
+        self._search = Text()
+        self._search.observe(self._filter_options, 'value')
+
+        # Define Layout
+        button_box = VBox([self._buttons[True], self._buttons[False]],
+                          layout=Layout(margin='auto 0'))
+        self._composite = HBox([VBox([self._search, self._lists[False]]),
+                                button_box, self._lists[True]],
+                               layout=Layout(margin='0'))
+
+        self.observe(self._update_options, 'options')
+        self.observe(self._update_value, 'value')
+
+        self._selected = {False: [], True: []}
+        self._query = ''
+        super(CrossSelect, self).__init__(*args, **dict(kwargs, options=options))
+
+
+    def _update_value(self, event):
+        selected = [self._reverse_lookup.get(v, v) for v in event['new']]
+        self._lists[True].options = selected
+        self._lists[True].value = []
+        self._lists[False].options = [o for o in self.options
+                                      if o not in selected]
+
+    def _update_options(self, event):
+        """
+        Updates the options of each of the sublists after the options
+        for the whole widget are updated.
+        """
+        self._reverse_lookup = {v: k for k, v in event['new'].items()}
+        options = event['new'].keys() if isinstance(event, dict) else event['new']
+        self._selected[False] = []
+        self._selected[True] = []
+        self._lists[True].options = ['']
+        self._lists[True].value = []
+        self._lists[False].options = options
+        self._lists[False].value = []
+        self._filter_options()
+
+    def _filter_options(self, event=None):
+        """
+        Filters unselected options based on a text query event.
+        """
+        query = self._query if event is None else event['new'] 
+        self._query = query
+        whitelist = self._lists[True].options
+        options = [o for o in self.options
+                   if o not in whitelist]
+        if not query:
+            self._lists[False].options = options
+            self._lists[False].value = []
+        else:
+            matches = fnmatch.filter(options, query+'*')
+            self._lists[False].options = matches if matches else ['']
+            self._lists[False].value = matches
+
+    def _update_selection(self, event):
+        """
+        Updates the current selection in each list.
+        """
+        selected = event['owner'] is self._lists[True]
+        self._selected[selected] = [v for v in event['new'] if v != '']
+
+    def _apply_selection(self, event):
+        """
+        Applies the current selection depending on which button was
+        pressed.
+        """
+        selected = event is self._buttons[True]
+        new = self._selected[not selected]
+        old = self._lists[selected].options
+        other = self._lists[not selected].options
+        
+        merged = sorted([v for v in list(old) + list(new) if v != ''])
+        leftovers = sorted([o for o in other if o not in new and o != ''])
+        new_values = merged if selected else leftovers
+        self._lists[selected].options = merged if merged else ['']
+        self._lists[not selected].options = leftovers if leftovers else ['']
+        self.value = [self._options_dict[o] for o in self._lists[True].options if o != '']
+        self._filter_options()
+
+    def _ipython_display_(self, **kwargs):
+        """
+        Displays the composite widget.
+        """
+        self._composite._ipython_display_(**kwargs)
+    
+    def get_state(self, key=None, drop_defaults=False):
+        """
+        HACK: Let's this composite widget pretend to be a regular widget
+        when included into a layout.
+        """
+        if key == 'value':
+            return {'value': self._lists[True].options}
+        elif key == '_options_labels':
+            return super(CrossSelect, self).get_state(key, drop_defaults)
+        return self._composite.get_state(key, drop_defaults)
+

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -128,9 +128,9 @@ class CrossSelect(SelectMultiple):
         self._composite._ipython_display_(**kwargs)
     
     def get_state(self, key=None, drop_defaults=False):
-        # HACK: Let's this composite widget pretend to be a regular widget
+        # HACK: Lets this composite widget pretend to be a regular widget
         # when included into a layout.
         if key in ['value', '_options_labels']:
-            return super(CrossSelect, self).get_state(key, drop_defaults)
-        return self._composite.get_state(key, drop_defaults)
+            return super(CrossSelect, self).get_state(key)
+        return self._composite.get_state(key)
 


### PR DESCRIPTION
Adds a complex multi-select widget called ``CrossSelector`` which allows selecting items from a list by moving them from one list to another. The ``CrossSelector`` pretends to be a regular widget by hacking some of the methods ensuring that the traitlets of the outer widget are synced with the internal representation. Currently the widget gets used when there are more than 20 options in a ``param.ListSelector``. It looks something like this and combines seamlessly with the ``MultiFileSelector``:

<img width="782" alt="screen shot 2017-02-08 at 1 06 24 pm" src="https://cloud.githubusercontent.com/assets/1550771/22738450/6ebe7ed8-edff-11e6-9319-4837c788af9f.png">

The search function uses ``fnmatch`` for matching but automatically adds a wildcard to the end ensuring that it matches as you type. Better suggestions welcome, other filtering widgets out there generally just match based on whether any item contains the query substring.

Still needs a bit of cleanup.