### PR TITLE
Added View parameters and widgets

### DIFF
--- a/doc/ViewParameters.ipynb
+++ b/doc/ViewParameters.ipynb
@@ -41,7 +41,7 @@
     "class Example(param.Parameterized):\n",
     "    \n",
     "    magnitude = param.Number(1, bounds=(0, 10))\n",
-    "    \n",
+    "\n",
     "    output = paramnb.view.HTML()\n",
     "    \n",
     "    def update(self):\n",
@@ -58,7 +58,7 @@
     "editable": true
    },
    "source": [
-    "The ``HTML`` parameter accepts any arbitrary HTML string but for convenience paramNB also supplies a ``HView`` parameter to render ``HoloViews`` objects, which allows building complex GUIs and dashboards very easily. In this case we declare to parameters to control the ``amplitude`` and ``frequency`` of a sine curve and then declare an ``HView`` parameter to display the output. Additionally we can declare the ``view_position``, which declares where the viewing widget will be placed in relation to the input widgets:"
+    "The ``HTML`` parameter accepts any arbitrary HTML string but for convenience paramNB also allows supplying a custom ``renderer`` function, which converts the view data to HTML. In this case we declare to parameters to control the ``amplitude`` and ``frequency`` of a sine curve and then declare an ``HTML`` parameter which uses a HoloViews MPLRenderer to render the output. Additionally we can declare the ``view_position``, which specifies where the viewing widget will be placed in relation to the input widgets:"
    ]
   },
   {
@@ -73,6 +73,7 @@
    "source": [
     "import holoviews as hv\n",
     "import holoviews.plotting.mpl\n",
+    "renderer = hv.Store.renderers['matplotlib']\n",
     "\n",
     "class Example(param.Parameterized):\n",
     "    \n",
@@ -80,10 +81,14 @@
     "    \n",
     "    frequency = param.Number(default=2, bounds=(1, 10))\n",
     "    \n",
-    "    output = paramnb.view.HView()\n",
+    "    element = param.ObjectSelector(default=hv.Curve,\n",
+    "                                   objects=[hv.Curve, hv.Scatter, hv.Area],\n",
+    "                                   precedence=0)\n",
+    "    \n",
+    "    output = paramnb.view.Image(renderer=lambda x: renderer(x)[0])\n",
     "\n",
     "    def update(self):\n",
-    "        self.output = hv.Curve(self.amplitude*np.sin(np.linspace(0, np.pi*self.frequency)))\n",
+    "        self.output = self.element(self.amplitude*np.sin(np.linspace(0, np.pi*self.frequency)))\n",
     "\n",
     "example = Example()\n",
     "paramnb.Widgets(example, callback=example.update, view_position='right')"

--- a/doc/ViewParameters.ipynb
+++ b/doc/ViewParameters.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "import paramnb\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "The paramNB library provides an easy way to manipulate parameters on ``Parameterized`` using the widgets in the notebook. In addition to controlling input parameters a common usecase for using widgets in the notebook is to dynamically control some visual display output. In addition to all the standard parameters supplied by the ``param`` library, ``paramNB`` also supplies so called ``View`` parameters, which render their output in a widget area. The output parameters may be updated simply by setting the parameter on the class.\n",
+    "\n",
+    "In the first simple example we will declare a Parameterized class with a ``Number`` parameter called magnitude and an ``HTML`` parameter which will let us display some arbitrary HTML. In this case we will simply generate a pandas dataframe with random data within the update method and use the ``to_html`` method to convert it to an HTML table. If we define the ``update`` method as the callback of the widgets the table will now update whenever the slider is dragged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "class Example(param.Parameterized):\n",
+    "    \n",
+    "    magnitude = param.Number(1, bounds=(0, 10))\n",
+    "    \n",
+    "    output = paramnb.view.HTML()\n",
+    "    \n",
+    "    def update(self):\n",
+    "        self.output = pd.DataFrame(np.random.rand(10,2)*self.magnitude).to_html()\n",
+    "\n",
+    "example = Example()\n",
+    "paramnb.Widgets(example, callback=example.update)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "The ``HTML`` parameter accepts any arbitrary HTML string but for convenience paramNB also supplies a ``HView`` parameter to render ``HoloViews`` objects, which allows building complex GUIs and dashboards very easily. In this case we declare to parameters to control the ``amplitude`` and ``frequency`` of a sine curve and then declare an ``HView`` parameter to display the output. Additionally we can declare the ``view_position``, which declares where the viewing widget will be placed in relation to the input widgets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "import holoviews.plotting.mpl\n",
+    "\n",
+    "class Example(param.Parameterized):\n",
+    "    \n",
+    "    amplitude = param.Number(default=2, bounds=(2, 5))\n",
+    "    \n",
+    "    frequency = param.Number(default=2, bounds=(1, 10))\n",
+    "    \n",
+    "    output = paramnb.view.HView()\n",
+    "\n",
+    "    def update(self):\n",
+    "        self.output = hv.Curve(self.amplitude*np.sin(np.linspace(0, np.pi*self.frequency)))\n",
+    "\n",
+    "example = Example()\n",
+    "paramnb.Widgets(example, callback=example.update, view_position='right')"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -247,7 +247,7 @@ class Widgets(param.ParameterizedFunction):
              z-index: 100; min-width: 100px; font-size: 80%}
           .ttip:hover .ttiptext { visibility: visible; }
           .widget-dropdown .dropdown-menu { width: 100% }
-          .widget-select-multiple select { min-height: 140px; min-width: 300px;}
+          .widget-select-multiple select { min-height: 100px; min-width: 300px;}
         </style>
         """
 

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -269,7 +269,7 @@ class Widgets(param.ParameterizedFunction):
         display(Javascript(WIDGET_JS))
         display(display_output)
 
-        if self.p.on_init:
+        if self.p.on_init or outputs:
             self.execute(None)
 
     def _update_trait(self, p_name, p_value):

--- a/paramnb/view.py
+++ b/paramnb/view.py
@@ -1,0 +1,47 @@
+import param
+
+class _View(param.Parameter):
+    """
+    Output parameters allow representing some output to be displayed.
+    Output parameters may have a callback, which is called when a new
+    value is set on the parameter. Additionally they should implement
+    a render method, which returns the data in a displayable format,
+    e.g. HTML.
+    """
+
+    __slots__ = ['callback']
+
+    def render(self, value):
+        return value
+
+    def __init__(self, default=None, callback=None,**kwargs):
+        self.callback = None
+        super(_View, self).__init__(default, **kwargs)
+
+    def __set__(self, obj, val):
+        super(_View, self).__set__(obj, val)
+        if self.callback:
+            self.callback(self.render(val))
+
+
+class HTML(_View, param.String):
+    """
+    HTML is a View parameter that allows displaying HTML output.
+    """
+
+
+class HView(_View):
+    """
+    HView is an View parameter meant for displaying HoloViews objects.
+    In combination with HoloViews streams this parameter may be used
+    to build complex dashboards.
+    """
+
+    def render(self, value):
+        import holoviews as hv
+        backend = hv.Store.current_backend
+        renderer = hv.Store.renderers[backend]
+        plot = renderer.get_plot(value)
+        plot.initialize_plot()
+        size = renderer.get_size(plot)
+        return renderer.html(plot), size

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -6,11 +6,11 @@ from param.parameterized import classlist
 import ipywidgets
 from ipywidgets import (SelectMultiple, Button, HBox, VBox, Layout,
                         Text, HTML, FloatSlider, FloatText, IntText,
-                        IntSlider, SelectMultiple)
+                        IntSlider, SelectMultiple, Image)
 from traitlets import Unicode
 
 from .util import named_objs
-from .view import HTML as HTMLView, HView
+from .view import HTML as HTMLView, Image as ImageView
 
 
 def FloatWidget(*args, **kw):
@@ -242,7 +242,7 @@ ptype2wtype = {
     param.ListSelector:  ListSelectorWidget,
     param.Action:        ActionButton,
     HTMLView:            ActiveHTMLWidget,
-    HView:               ActiveHTMLWidget
+    ImageView:           Image
 }
 
 def wtype(pobj):

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -1,7 +1,8 @@
 import re
 
 import param
-from ipywidgets import SelectMultiple, Button, HBox, VBox, Layout, Text
+from ipywidgets import SelectMultiple, Button, HBox, VBox, Layout, Text, HTML
+from traitlets import Unicode
 
 from .util import named_objs
 
@@ -148,3 +149,26 @@ class CrossSelect(SelectMultiple):
             return super(CrossSelect, self).get_state(key)
         return self._composite.get_state(key)
 
+
+
+HTMLVIEW_JS = """
+define('activehtml', ["jupyter-js-widgets"], function(widgets) {
+    var ActiveHTMLView = widgets.HTMLView.extend({
+        update: function() {
+            $(this.el).html(this.model.get('value'));
+        }
+    });
+    return {
+        ActiveHTMLView: ActiveHTMLView
+    };
+});
+"""
+
+class ActiveHTMLWidget(HTML):
+    _view_name = Unicode('ActiveHTMLView').tag(sync=True)
+    _view_module = Unicode('activehtml').tag(sync=True)
+    value = Unicode('').tag(sync=True)
+
+
+
+WIDGET_JS = ''.join([HTMLVIEW_JS])


### PR DESCRIPTION
This PR adds the concept of ``Output`` parameters and widgets to paramnb. Unlike the other parameter types ``Output`` widgets do not respond to changes on the frontend instead the corresponding parameters have callbacks which are triggered when they are updated. This means that the display can be updated by setting the parameter, allowing plots to be switched in response to parameter changes.

Output parameters differ from other parameters in two main ways:

1. They have a ``callback`` attribute, which allows paramnb to install itself as a callback, whenever the parameter value changes the callback is called and the ipywidgets traitlet is updated along with it.

2. They have a ``render`` method, which allows rendering the current parameter value to HTML. This allows having custom output parameters like HoloViewsOutput, which automatically renders any HoloViews object to HTML.

Simple HTML example:

```python
class Example(param.Parameterized):
    
    a = param.Number(1, bounds=(0, 10))
    
    output = paramnb.HTMLOutput()
    
    def update(self, **kwargs):
        self.output = pd.DataFrame(np.random.rand(10,2)*self.a).to_html()

example = Example()
paramnb.Widgets(example, on_init=True, callback=example.update)
```

<img width="260" alt="screen shot 2017-02-16 at 12 44 58 pm" src="https://cloud.githubusercontent.com/assets/1550771/23021821/c3adc402-f445-11e6-9c4e-2bbb3b1f8e17.png">

```python
class Example(param.Parameterized):
    
    a = param.Number(1, bounds=(0, 10))
    
    output = paramnb.HoloViewsOutput()
    
    def update(self, **kwargs):
        self.output = hv.Curve(np.random.rand(10)+self.a)

example = Example()
paramnb.Widgets(example, on_init=True, callback=example.update)
```

<img width="278" alt="screen shot 2017-02-16 at 12 45 45 pm 1" src="https://cloud.githubusercontent.com/assets/1550771/23021836/dba830e2-f445-11e6-8673-9cd2a46f4a72.png">

To do:

- [x] Factor out holoviews plot size finding code to HoloViews renderers
- [x] Separate input and output widgets into separate containers