### PR TITLE
Pass changed kwargs to callback

### DIFF
--- a/paramnb/util.py
+++ b/paramnb/util.py
@@ -1,4 +1,5 @@
 import sys
+import inspect
 from collections import OrderedDict
 
 if sys.version_info.major == 3:
@@ -29,3 +30,15 @@ def named_objs(objlist):
             k = as_unicode(k)
         objs[k] = obj
     return objs
+
+
+def get_method_owner(meth):
+    """
+    Returns the instance owning the supplied instancemethod or
+    the class owning the supplied classmethod.
+    """
+    if inspect.ismethod(meth):
+        if sys.version_info < (3,0):
+            return meth.im_class if meth.im_self is None else meth.im_self
+        else:
+            return meth.__self__


### PR DESCRIPTION
It is often useful for the paramnb.Widgets callback to know which exact parameter has changed. This PR ensures the changed parameter is passed to the callback function as kwargs. It also fixes a python 3 bug in avoiding passing the parameterized instance/class to a callback which is also a method on that class/instance.