### PR TITLE
Added Color, Range and Date widgets

### DIFF
--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "urth": {
      "dashboard": {
       "hidden": true
@@ -19,24 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "50000"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import param\n",
+    "import datetime as dt\n",
     "\n",
     "def hello(x):\n",
     "    print(\"Hello %s\" % x)\n",
@@ -51,11 +45,15 @@
     "    float_with_soft_bounds  = param.Number(0.5,bounds=(0,None),softbounds=(0,2))\n",
     "    unbounded_float         = param.Number(30.01,precedence=0)\n",
     "    hidden_parameter        = param.Number(2.718,precedence=-1)\n",
+    "    integer_range           = param.Range(default=(3,7),bounds=(0, 10))\n",
+    "    float_range             = param.Range(default=(0,1.57),bounds=(0, 3.145))\n",
     "    dictionary              = param.Dict(default={\"a\":2, \"b\":9},constant=True)\n",
     "    \n",
     "class Example(BaseClass):\n",
     "    \"\"\"An example Parameterized class\"\"\"\n",
     "    boolean                 = param.Boolean(True, doc=\"A sample Boolean parameter\")\n",
+    "    color                   = param.Color(default='#FF00FF')\n",
+    "    date                    = param.Date(bounds=(dt.datetime(2017, 1, 1), dt.datetime(2017, 2, 1)))\n",
     "    select_string           = param.ObjectSelector(default=\"yellow\",objects=[\"red\",\"yellow\",\"green\"])\n",
     "    select_fn               = param.ObjectSelector(default=list,objects=[list,set,dict])\n",
     "    int_list                = param.ListSelector(default=[3,5], objects=[1,3,5,7,9],precedence=0.5)\n",
@@ -68,7 +66,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "As you can see, declaring Parameters depends only on the separate Param library.  Parameters are a simple idea with some properties that are crucial for helping you create clean, usable code:\n",
     "\n",
@@ -81,9 +82,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "urth": {
      "dashboard": {
       "hidden": true
@@ -98,7 +101,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "As you can see, `paramnb.Widgets` does not need to be provided with any knowledge of your domain-specific application, not even the names of your parameters; it simply displays widgets for whatever Parameters may have been defined on that object.  Using Param with ParamNB thus achieves a nearly complete separation between your domain-specific code and your display code, making it vastly easier to maintain both of them over time.  Here even the `msg` button was specified declaratively, as an action that can be invoked (printing \"Hello\") independently of whether it is used in a GUI or other context.\n",
     "\n",
@@ -109,53 +115,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "23"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Example.unbounded_int"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "50000"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Example.num_int"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -164,7 +154,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "As you can see, you can access the parameter values at the class level in this way from within the notebook to control behavior explicitly, e.g. to select what to show in subsequent cells.  Moreover, any instances of the Parameterized classes in your own code will now use the new parameter values unless specifically overridden in that instance, so you can now import and use your domain-specific library however you like, knowing that it will use your interactive selections wherever those classes appear.  None of the domain-specific code needs to know or care that you used ParamNB; it will simply see new values for whatever attributes were changed.\n",
     "\n",
@@ -190,9 +183,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -205,29 +200,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(3.14, 2)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Example2.num1, Example2.number2"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Notice that in a live notebook, the `In` and `Out` numbers of the above cell increase every time you drag a slider, because that cell is being re-executed.  \n",
     "\n",
@@ -236,9 +225,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -247,29 +238,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(3.14, 2)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Example2.num1, Example2.number2"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Here, the cell above changes its number (and output value) only when the \"Run 1\" button is pressed in the previous cell.  The supplied callback is also executed at that time.\n",
     "\n",


### PR DESCRIPTION
Depends on https://github.com/ioam/param/pull/144 but is backward compatible. Here's what the index.ipynb example looks like now:

<img width="373" alt="screen shot 2017-02-26 at 5 47 19 pm" src="https://cloud.githubusercontent.com/assets/1550771/23342084/bf6c1ade-fc4b-11e6-9467-99815c81dc41.png">
