### PR TITLE
Add literal evaluation and warn about validation

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import sys
 import os
+import ast
 import types
 import itertools
 import json
@@ -197,7 +198,18 @@ class Widgets(param.ParameterizedFunction):
 
         def change_event(event):
             new_values = event['new']
-            setattr(self.parameterized, p_name, new_values)
+            if isinstance(w, ipywidgets.Text):
+                try:
+                    new_values = ast.literal_eval(new_values)
+                except:
+                    w.layout.border = '5px solid #cc0000'
+            try:
+                setattr(self.parameterized, p_name, new_values)
+            except ValueError:
+                w.layout.border = '5px solid #cc0000'
+                return
+            else:
+                w.layout.border = '0px'
             if not self.p.button:
                 self.execute({p_name: new_values})
 

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -23,7 +23,7 @@ import ipywidgets
 import param
 
 from . import view
-from .widgets import wtype, WIDGET_JS
+from .widgets import wtype, WIDGET_JS, apply_error_style, literal_params
 from .util import named_objs, get_method_owner
 from .view import _View
 
@@ -198,19 +198,25 @@ class Widgets(param.ParameterizedFunction):
 
         def change_event(event):
             new_values = event['new']
-            if isinstance(w, ipywidgets.Text):
+            error = False
+            # Apply literal evaluation to values
+            if (isinstance(w, ipywidgets.Text) and isinstance(p_obj, literal_params)):
                 try:
                     new_values = ast.literal_eval(new_values)
                 except:
-                    w.layout.border = '5px solid #cc0000'
-            try:
-                setattr(self.parameterized, p_name, new_values)
-            except ValueError:
-                w.layout.border = '5px solid #cc0000'
-                return
-            else:
-                w.layout.border = '0px'
-            if not self.p.button:
+                    error = True
+
+            # If no error during evaluation try to set parameter
+            if not error:
+                try:
+                    setattr(self.parameterized, p_name, new_values)
+                except ValueError:
+                    error = True
+
+            # Style widget to denote error state
+            apply_error_style(w, error)
+
+            if not error and not self.p.button:
                 self.execute({p_name: new_values})
 
         if hasattr(p_obj, 'callback'):

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -271,8 +271,19 @@ class ActiveHTMLWidget(HTML):
     value = Unicode('').tag(sync=True)
 
 
+def apply_error_style(w, error):
+    "Applies error styling to the supplied widget based on the error code"
+    if error:
+        w.layout.border = '5px solid #cc0000'
+    else:
+        w.layout.border = '0px'
+
+
 # Combine all widget JS code into on variable
 WIDGET_JS = ''.join([HTMLVIEW_JS])
+
+# Define parameters which should be evaluated using ast.literal_eval
+literal_params = (param.Dict, param.List, param.Tuple)
 
 # Maps from Parameter type to ipython widget types with any options desired
 ptype2wtype = {

--- a/paramnb/widgets.py
+++ b/paramnb/widgets.py
@@ -65,6 +65,9 @@ class RangeWidget(param.ParameterizedFunction):
        Number of steps used to compute step size for float range.""")
 
     def __call__(self, *args, **kw):
+        has_bounds = not (kw['min'] is None or kw['max'] is None)
+        if not has_bounds:
+            return TextWidget(*args,**kw)
         if all(kw[k] is None or isinstance(kw[k], int)
                for k in ['min', 'max']):
             widget = IntRangeSlider
@@ -274,6 +277,7 @@ WIDGET_JS = ''.join([HTMLVIEW_JS])
 # Maps from Parameter type to ipython widget types with any options desired
 ptype2wtype = {
     param.Parameter:     TextWidget,
+    param.Dict:          TextWidget,
     param.Selector:      ipywidgets.Dropdown,
     param.Boolean:       ipywidgets.Checkbox,
     param.Number:        FloatWidget,


### PR DESCRIPTION
Adds literal evaluation for parameters using the TextWidget, tested it for all widgets. Additionally also warn on validation errors by setting the border of the widget to red.

![val_error](https://cloud.githubusercontent.com/assets/1550771/23345027/fcb009e0-fc7e-11e6-9954-a78e81945e11.gif)
