### PR TITLE
Made continuous_update=False by default

### DIFF
--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -176,13 +176,13 @@
     "\n",
     "* `button=False`: the default; the specified code will be executed whenever a widget value is changed\n",
     "* `button=True`: Provide a button to control code execution, so that multiple widgets can be adjusted and code is updated only when the button is pushed.\n",
-    "* `continuous_update=True`: the default; the specified code is executed for every movement of a slider\n",
-    "* `continuous_update=False`: the specified code is executed only once a widget has been released\n",
+    "* `continuous_update=True`: the specified code is executed for every movement of a slider\n",
+    "* `continuous_update=False`: the default; the specified code is executed only once a widget has been released\n",
     "\n",
     "These options allow you to choose between various levels of dynamic interactivity, as appropriate for the computational and semantic requirements of the code you are executing.  Rough guidelines:\n",
     "\n",
     "* `button=False,continuous_update=True`: Provides a smooth, dynamic user experience, with text or plots updating immediately as a slider is dragged. Appropriate only for inexpensive operations, where rexecuting the code multiple times on the fly is not an issue.\n",
-    "* `button=False,continuous_update=False`: A good middle ground appropriate for most interactive use, with relatively responsive interactivity, updating each time a widget is released.  Suitable for relatively expensive operations, but not so expensive that it is problematic to have them run once for each widget adjusted.\n",
+    "* `button=False,continuous_update=False`: The default; a good middle ground appropriate for most interactive use, with relatively responsive interactivity, updating each time a widget is released.  Suitable for relatively expensive operations, but not so expensive that it is problematic to have them run once for each widget adjusted.\n",
     "* `button=True`: Suitable for very expensive or transactional operations, where you want to adjust multiple widgets before committing to executing the code.\n",
     "\n",
     "Example of dynamic updating:"
@@ -202,7 +202,7 @@
     "    num1 = param.Number(3.14,bounds=(0.0,10.0))\n",
     "    number2 = param.Integer(2,bounds=(0,5))\n",
     "\n",
-    "paramnb.Widgets(Example2,next_n=1,continuous_update=False)"
+    "paramnb.Widgets(Example2,next_n=1)"
    ]
   },
   {

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -124,7 +124,7 @@ class Widgets(param.ParameterizedFunction):
                                   objects=['row','column'],doc="""
         Whether to lay out the buttons as a row or a column.""")
 
-    continuous_update = param.Boolean(default=True, doc="""
+    continuous_update = param.Boolean(default=False, doc="""
         If true, will continuously update the next_n and/or callback, 
         if any, as a slider widget is dragged.""")
 


### PR DESCRIPTION
My best guess is that button=False and continuous_update=False is the most useful default -- it can handle even very expensive callback/cell operations, but doesn't need any special machinery, extra clicks, etc. to force updating.  Given that paramnb 2.0 was only released earlier today, I propose that we make this change now in 2.0.1 and consider it part of 2.0's API/behavior changes compared to 1.x.

@philippjfr, if you agree, please merge this before releasing.  Otherwise, please delete this.