### PR TITLE
Only set widget tooltip if doc is not None

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -184,7 +184,11 @@ class Widgets(param.ParameterizedFunction):
         widget_class = wtype(p_obj)
 
         value = getattr(self.parameterized, p_name)
-        kw = dict(tooltip=p_obj.doc, value=value)
+
+        kw = dict(value=value)
+        if p_obj.doc:
+            kw['tooltip'] = p_obj.doc
+
         if isinstance(p_obj, param.Action):
             def action_cb(button):
                 value(self.parameterized)


### PR DESCRIPTION
Would previously raise errors in some cases because the tooltip cannot be None.