### PR TITLE
View parameters store callback per Parameterized instance

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -198,7 +198,7 @@ class Widgets(param.ParameterizedFunction):
 
         kw['continuous_update']=self.p.continuous_update
 
-        if hasattr(p_obj, 'callback'):
+        if hasattr(p_obj, 'callbacks'):
             kw.pop('value', None)
 
         if hasattr(p_obj, 'get_range'):
@@ -209,7 +209,7 @@ class Widgets(param.ParameterizedFunction):
 
         w = widget_class(**kw)
 
-        if hasattr(p_obj, 'callback') and value is not None:
+        if hasattr(p_obj, 'callbacks') and value is not None:
             self._update_trait(p_name, p_obj.renderer(value), w)
 
         def change_event(event):
@@ -237,8 +237,8 @@ class Widgets(param.ParameterizedFunction):
             else:
                 self._changed[p_name] = new_values
 
-        if hasattr(p_obj, 'callback'):
-            p_obj.callback = functools.partial(self._update_trait, p_name)
+        if hasattr(p_obj, 'callbacks'):
+            p_obj.callbacks[id(self.parameterized)] = functools.partial(self._update_trait, p_name)
         else:
             w.observe(change_event, 'value')
 

--- a/paramnb/view.py
+++ b/paramnb/view.py
@@ -10,17 +10,18 @@ class _View(param.Parameter):
     and may optionally supply the desired size of the viewport.
     """
 
-    __slots__ = ['callback', 'renderer']
+    __slots__ = ['callbacks', 'renderer']
 
     def __init__(self, default=None, callback=None, renderer=None, **kwargs):
-        self.callback = None
+        self.callbacks = {}
         self.renderer = (lambda x: x) if renderer is None else renderer
         super(_View, self).__init__(default, **kwargs)
 
     def __set__(self, obj, val):
         super(_View, self).__set__(obj, val)
-        if self.callback:
-            self.callback(self.renderer(val))
+        obj_id = id(obj)
+        if obj_id in self.callbacks:
+            self.callbacks[obj_id](self.renderer(val))
 
 
 class HTML(_View):


### PR DESCRIPTION
This bug took me ages to figure out. The View parameters have a ``callback`` attribute which allows them to be called in response to a ``__set__`` event. Since a Parameter is instantiated once per Parameterized class all the instances of the Parameterized class will share the same view parameters and therefore the callback will be overridden for each set of widgets that is displayed. This means if you use param.Widgets on the same class or a subclass any previous displayed plots will update the newly displayed viewing area rather than the old one. This PR adds a callbacks dictionary, which allows registering callbacks by the ``id`` of the Parameterized instance so widgets for multiple instances can be displayed and updated independently.