### PR TITLE
Added registry of 'watchers', allowing functions to be executed when …

### DIFF
--- a/doc/WidgetLinking.ipynb
+++ b/doc/WidgetLinking.ipynb
@@ -20,9 +20,31 @@
    },
    "outputs": [],
    "source": [
+    "# we'd add get_soft_range() to relevant parameters in param\n",
+    "class ObjectSelector2(param.ObjectSelector):\n",
+    "    __slots__ = ['softbounds']\n",
+    "    def __init__(self,default=None,objects=None,instantiate=False,\n",
+    "                 compute_default_fn=None,check_on_set=None,allow_None=None,softbounds=None,**params): \n",
+    "        self.softbounds=softbounds if softbounds is not None else objects        \n",
+    "        super(ObjectSelector2,self).__init__(\n",
+    "            default=default,objects=objects,instantiate=instantiate,\n",
+    "            compute_default_fn=compute_default_fn,check_on_set=check_on_set,allow_None=allow_None,**params)\n",
+    "        \n",
+    "    def get_soft_range(self):\n",
+    "        return param.named_objs(self.softbounds)\n",
+    "\n",
+    "param.ObjectSelector2 = ObjectSelector2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "class SomeManagement(param.Parameterized):\n",
-    "    employee = param.ObjectSelector(default='Person Z',objects=['Person X','Person Y','Person Z'])\n",
-    "    project = param.ObjectSelector(default='A',objects=['A','B','C','D','E','F','G','H'])\n",
+    "    employee = param.ObjectSelector2(default='Person Z',objects=['Person X','Person Y','Person Z'])\n",
+    "    project = param.ObjectSelector2(default='A',objects=['A','B','C','D','E','F','G','H'])\n",
     "    days = param.Integer(default=1,softbounds=(0,10),precedence=1)"
    ]
   },
@@ -75,8 +97,8 @@
    },
    "outputs": [],
    "source": [
-    "def update_days(widgets,**params):\n",
-    "    widgets['days'].max = speed[params['employee']]"
+    "def update_days(parameterized):\n",
+    "    parameterized.params('days').softbounds = (0,speed[parameterized.employee])"
    ]
   },
   {
@@ -87,15 +109,15 @@
    },
    "outputs": [],
    "source": [
-    "def update_projects(widgets,**params):\n",
-    "    widgets['project'].options = capabilities[params['employee']]"
+    "def update_projects(parameterized):\n",
+    "    parameterized.params('project').softbounds = capabilities[parameterized.employee]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [

--- a/doc/WidgetLinking.ipynb
+++ b/doc/WidgetLinking.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "import paramnb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class SomeManagement(param.Parameterized):\n",
+    "    employee = param.ObjectSelector(default='Person Z',objects=['Person X','Person Y','Person Z'])\n",
+    "    project = param.ObjectSelector(default='A',objects=['A','B','C','D','E','F','G','H'])\n",
+    "    days = param.Integer(default=1,softbounds=(0,10),precedence=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m = SomeManagement()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "capabilities = {  \n",
+    "    'Person X' : ('A','B','C','D'),\n",
+    "    'Person Y' : ('A','B','E','F'),\n",
+    "    'Person Z' : ('G','H'),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "speed = {\n",
+    "    'Person X' : 10,\n",
+    "    'Person Y' : 20,\n",
+    "    'Person Z' : 30,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def update_days(widgets,**params):\n",
+    "    widgets['days'].max = speed[params['employee']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def update_projects(widgets,**params):\n",
+    "    widgets['project'].options = capabilities[params['employee']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "paramnb.Widgets(m, watchers={'employee':(update_projects,update_days)})"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -132,8 +132,7 @@ class Widgets(param.ParameterizedFunction):
         Registry of functions to call whenever a parameter's widget value 
         is changed. 
 
-        Functions will be passed the widgets dictionary and a dictionary 
-        of parameter values.
+        Functions will be passed the parameterized object.
 
         Dictionary of lists :(
         """)
@@ -302,7 +301,22 @@ class Widgets(param.ParameterizedFunction):
         
         for param in changed:
             for fn in self.p.watchers.get(param,[]):
-                fn(self._widgets,**param_values)
+                fn(self.parameterized)
+
+        for param in param_values:
+            p_obj = self.parameterized.params(param)
+
+            # TODO: as suggested by Philipp, should factor out
+            # converting parameter attributes to ipywidget attributes
+            # e.g. have a registry of functions ;) or more likely some
+            # kind of update method that's used during creation and
+            # here.
+            if hasattr(p_obj, 'get_soft_range'):
+                self._widgets[param].options = p_obj.get_soft_range()
+            elif hasattr(p_obj, 'get_soft_bounds'):
+                min,max=p_obj.get_soft_bounds()
+                self._widgets[param].min = min
+                self._widgets[param].max = max
 
 
     def execute(self, changed={}):


### PR DESCRIPTION
I've begun "Solve at param GUI toolkit level?" from https://github.com/ioam/param/issues/160 and have opened this PR to ask for feedback, not to merge. In particular, I am looking for more real world use cases to address. Anyone got any notebooks with examples where they have already done or want to do this kind of thing? (I'm working on a DateRange parameter and corresponding paramnb widget.)

Note that when you write code to link parameters the way I've done here, you currently have to know about both the widgets and the parameters :( E.g. 

```
def update_days(widgets,**params):
    widgets['days'].max = speed[params['employee']]
```

What we discussed before was instead to update the parameter, and have that be reflected in the widget. So in this case it would mean setting the parameter's soft bounds, and seeing that updated in the slider. However, I'm not yet sure how that approach would work for parameters that don't have an equivalent of soft bounds (e.g. object selectors). But anyway, I guess the next step is to make it so that you only have to update the parameters.



