### PR TITLE
Instantiate selection for ClassSelector(is_instance=True); fixes #49.

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -225,6 +225,8 @@ class Widgets(param.ParameterizedFunction):
                 except:
                     error = 'eval'
             elif hasattr(p_obj,'is_instance') and p_obj.is_instance and isinstance(new_values,type):
+                # results in new instance each time non-default option
+                # is selected; could consider caching.
                 try:
                     new_values = new_values()
                 except:

--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -207,6 +207,9 @@ class Widgets(param.ParameterizedFunction):
         if hasattr(p_obj, 'get_soft_bounds'):
             kw['min'], kw['max'] = p_obj.get_soft_bounds()
 
+        if hasattr(p_obj,'is_instance') and p_obj.is_instance:
+            kw['options'][kw['value'].__class__.__name__]=kw['value']
+              
         w = widget_class(**kw)
 
         if hasattr(p_obj, 'callbacks') and value is not None:
@@ -221,6 +224,11 @@ class Widgets(param.ParameterizedFunction):
                     new_values = ast.literal_eval(new_values)
                 except:
                     error = 'eval'
+            elif hasattr(p_obj,'is_instance') and p_obj.is_instance and isinstance(new_values,type):
+                try:
+                    new_values = new_values()
+                except:
+                    error = 'instantiate'
 
             # If no error during evaluation try to set parameter
             if not error:


### PR DESCRIPTION
To support ``ClassSelector(is_instance=True)``, attempt to instantiate selected option.

Note: will result in new instance every time selection of non-default option is made. Could avoid that by updating the widget option list (replacing class with instance).
