### PR TITLE
ObjectSelectors default to first object from list if default is None.

### DIFF
--- a/paramnb/__init__.py
+++ b/paramnb/__init__.py
@@ -185,6 +185,12 @@ class Widgets(param.ParameterizedFunction):
 
         value = getattr(self.parameterized, p_name)
 
+        # For ObjectSelector, pick first from objects if no default;
+        # see https://github.com/ioam/param/issues/164
+        if hasattr(p_obj,'objects') and len(p_obj.objects)>0 and value is None:
+            value = p_obj.objects[0]            
+            setattr(self.parameterized, p_name, value)
+        
         kw = dict(value=value)
         if p_obj.doc:
             kw['tooltip'] = p_obj.doc


### PR DESCRIPTION
Plan to implement this in param (https://github.com/ioam/param/issues/164), but doing it in paramnb for now to get the behavior I want.